### PR TITLE
Add InputData schema and import

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
 from typing import List
+from backend.models import InputData
 
 # Pydantic models for request/response structures
 class CompanyInfo(BaseModel):
@@ -10,17 +11,6 @@ class CompanyInfo(BaseModel):
     secondaryColor: str
     logoDesc: str
     reportPeriod: str
-
-
-class InputData(BaseModel):
-    fleetScores: dict
-    hosViolations: dict
-    safetyEvents: dict
-    unassignedDriving: dict
-    speedingEvents: dict
-    personalConveyance: dict
-    missedDVIR: dict
-    contacts: List[str]
 
 
 class GenerateRequest(BaseModel):

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from typing import Dict, List
+
+class ScoreChange(BaseModel):
+    score: int
+    change: int
+
+class InputData(BaseModel):
+    fleetScores: Dict[str, ScoreChange]
+    hosViolations: Dict[str, int]
+    safetyEvents: Dict[str, int]
+    unassignedDriving: Dict[str, int]
+    speedingEvents: Dict[str, int]
+    personalConveyance: Dict[str, int]
+    missedDVIR: Dict[str, int]
+    contacts: List[str]


### PR DESCRIPTION
## Summary
- add Pydantic models `ScoreChange` and `InputData`
- refactor main API request to import `InputData` from the new module

## Testing
- `python -m py_compile backend/main.py backend/openai_client.py backend/models.py`

------
https://chatgpt.com/codex/tasks/task_e_6851a86d9478832cb4d9138737a3b55b