### PR TITLE
Add prompt logging

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -32,6 +32,10 @@ app = FastAPI(title="DOT Fleet Compliance Report Generator")
 
 @app.post("/generate", response_model=GenerateResponse)
 async def generate_report(payload: GenerateRequest):
+    # Build the prompt to verify placeholder data
+    from backend import openai_client
+    openai_client._build_prompt(payload.model_dump())
+
     # For now return a single stub section as placeholder
     return GenerateResponse(
         sections=[Section(title="Stub", markdown="Work in progress")]

--- a/backend/openai_client.py
+++ b/backend/openai_client.py
@@ -108,16 +108,22 @@ Professional, improvement‑focused, use DOT terms.
 ## 6 VISUAL RECREATION INSTRUCTIONS
 Colour palette & chart‑type guidance (see PDF for details)."""
 
-    return (template.replace("[COMPANY_NAME]", company["name"]).replace(
-        "[INDUSTRY_TYPE]", company["industry"]).replace(
-            "[PRIMARY_COLOR]", company["primaryColor"]).replace(
-                "[SECONDARY_COLOR]", company["secondaryColor"]).replace(
-                    "[LOGO_DETAILS]",
-                    company["logoDesc"]).replace("[REPORT_PERIOD]",
-                                                 company["reportPeriod"]))
+    filled = (
+        template.replace("[COMPANY_NAME]", company["name"]).replace(
+            "[INDUSTRY_TYPE]", company["industry"]).replace(
+                "[PRIMARY_COLOR]", company["primaryColor"]).replace(
+                    "[SECONDARY_COLOR]", company["secondaryColor"]).replace(
+                        "[LOGO_DETAILS]",
+                        company["logoDesc"]).replace(
+                            "[REPORT_PERIOD]",
+                            company["reportPeriod"]))
+
+    # Log the final prompt for debugging
+    print(filled)
+
+    return filled
 
 
-print(_build_prompt(req_json))
 
 
 def get_completion(payload: GenerateRequest) -> list[Section]:


### PR DESCRIPTION
## Summary
- print filled prompt in openai client for debugging
- call `_build_prompt` in `/generate` endpoint

## Testing
- `pytest -q`
- `uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload &` *(killed after test)*
- `curl -X POST http://localhost:8000/generate -H "Content-Type: application/json" -d '{"companyInfo":{"name":"ACME Logistics","industry":"Construction","primaryColor":"#2563EB","secondaryColor":"#DC2626","logoDesc":"Blue shield with white road icon","reportPeriod":"06/02/2025 – 06/08/2025"},"inputData":{"fleetScores":{"corporate":{"score":87,"change":-3},"greatLakes":{"score":92,"change":4},"ohioValley":{"score":81,"change":-1},"southeast":{"score":79,"change":5}},"hosViolations":{"foo":1},"safetyEvents":{},"unassignedDriving":{},"speedingEvents":{},"personalConveyance":{},"missedDVIR":{},"contacts":["ops@acme.com","fleet@acme.com"]}}'`

------
https://chatgpt.com/codex/tasks/task_e_6851b1b4a804832cbbffd6787247a643