### PR TITLE
Centralize OpenAI config

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,8 @@
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+OPENAI_TIMEOUT = int(os.getenv("OPENAI_TIMEOUT", 30000))

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 from typing import List
 from backend.models import InputData
+from backend.config import OPENAI_API_KEY, OPENAI_MODEL, OPENAI_TIMEOUT
 
 # Pydantic models for request/response structures
 class CompanyInfo(BaseModel):

--- a/backend/openai_client.py
+++ b/backend/openai_client.py
@@ -1,6 +1,6 @@
-import os
 import json
 import openai
+from backend.config import OPENAI_API_KEY, OPENAI_MODEL, OPENAI_TIMEOUT
 from .main import GenerateRequest, Section
 
 
@@ -119,11 +119,7 @@ Colour palette & chart‑type guidance (see PDF for details)."""
                             company["reportPeriod"]))
 
     # Log the final prompt for debugging
- eticp8-codex/add-print-statement-in-_build_prompt
-    # print(filled)
-=======
     print(filled)
-main
 
     return filled
 
@@ -131,12 +127,12 @@ main
 
 
 def get_completion(payload: GenerateRequest) -> list[Section]:
-    api_key = os.getenv("OPENAI_API_KEY")
+    api_key = OPENAI_API_KEY
     if not api_key:
         raise ValueError("OPENAI_API_KEY not set")
-    model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+    model = OPENAI_MODEL
 
-    client = openai.OpenAI(api_key=api_key)
+    client = openai.OpenAI(api_key=api_key, timeout=OPENAI_TIMEOUT/1000)
     messages = [{
         "role": "user",
         "content": _build_prompt(payload.model_dump())


### PR DESCRIPTION
## Summary
- add backend/config.py to load environment variables
- expose OPENAI constants in main.py
- read config values in openai_client

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `uvicorn backend.main:app --port 8000 --host 0.0.0.0 --reload`

------
https://chatgpt.com/codex/tasks/task_e_6851b7141090832cb7297a119a500bdc