### PR TITLE
Add React frontend with form scaffold

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "typescript": "^4.9.5"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.19"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>DOT Generator</title>
+</head>
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import DataInputForm from './components/DataInputForm';
+
+export default function App() {
+  return (
+    <div className="container mx-auto p-4">
+      <DataInputForm />
+    </div>
+  );
+}

--- a/frontend/src/components/DataInputForm.tsx
+++ b/frontend/src/components/DataInputForm.tsx
@@ -1,0 +1,231 @@
+import React, { useState } from 'react';
+
+interface ScoreChange {
+  score: number;
+  change: number;
+}
+
+interface CompanyInfo {
+  name: string;
+  industry: string;
+  primaryColor: string;
+  secondaryColor: string;
+  logoDesc: string;
+  reportPeriod: string;
+}
+
+interface InputData {
+  fleetScores: {
+    corporate: ScoreChange;
+    greatLakes: ScoreChange;
+    ohioValley: ScoreChange;
+    southeast: ScoreChange;
+  };
+  hosViolations: { total: number };
+  safetyEvents: { total: number };
+  unassignedDriving: { total: number };
+  speedingEvents: { total: number };
+  personalConveyance: { total: number };
+  missedDVIR: { total: number };
+  contacts: string[];
+}
+
+export default function DataInputForm() {
+  const [companyInfo, setCompanyInfo] = useState<CompanyInfo>({
+    name: '',
+    industry: '',
+    primaryColor: '',
+    secondaryColor: '',
+    logoDesc: '',
+    reportPeriod: '',
+  });
+
+  const [inputData, setInputData] = useState<InputData>({
+    fleetScores: {
+      corporate: { score: 0, change: 0 },
+      greatLakes: { score: 0, change: 0 },
+      ohioValley: { score: 0, change: 0 },
+      southeast: { score: 0, change: 0 },
+    },
+    hosViolations: { total: 0 },
+    safetyEvents: { total: 0 },
+    unassignedDriving: { total: 0 },
+    speedingEvents: { total: 0 },
+    personalConveyance: { total: 0 },
+    missedDVIR: { total: 0 },
+    contacts: [''],
+  });
+
+  const handleCompanyChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setCompanyInfo((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleFleetScoreChange = (
+    region: keyof InputData['fleetScores'],
+    field: keyof ScoreChange,
+    value: number
+  ) => {
+    setInputData((prev) => ({
+      ...prev,
+      fleetScores: {
+        ...prev.fleetScores,
+        [region]: { ...prev.fleetScores[region], [field]: value },
+      },
+    }));
+  };
+
+  const handleSimpleFieldChange = (
+    section:
+      | 'hosViolations'
+      | 'safetyEvents'
+      | 'unassignedDriving'
+      | 'speedingEvents'
+      | 'personalConveyance'
+      | 'missedDVIR',
+    value: number
+  ) => {
+    setInputData((prev) => ({
+      ...prev,
+      [section]: { total: value },
+    }));
+  };
+
+  const handleContactChange = (index: number, value: string) => {
+    setInputData((prev) => {
+      const contacts = [...prev.contacts];
+      contacts[index] = value;
+      return { ...prev, contacts };
+    });
+  };
+
+  const addContact = () => {
+    setInputData((prev) => ({ ...prev, contacts: [...prev.contacts, ''] }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    fetch('https://<YOUR_BACKEND>/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ companyInfo, inputData }),
+    })
+      .then((res) => res.json())
+      .then(console.log)
+      .catch(console.error);
+  };
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit}>
+      <h2 className="text-xl font-bold">Company Info</h2>
+      {(
+        [
+          'name',
+          'industry',
+          'primaryColor',
+          'secondaryColor',
+          'logoDesc',
+          'reportPeriod',
+        ] as (keyof CompanyInfo)[]
+      ).map((field) => (
+        <div key={field} className="flex flex-col">
+          <label className="font-medium capitalize" htmlFor={field}>
+            {field}
+          </label>
+          <input
+            id={field}
+            name={field}
+            type="text"
+            className="border p-2"
+            value={companyInfo[field]}
+            onChange={handleCompanyChange}
+          />
+        </div>
+      ))}
+
+      <h2 className="text-xl font-bold">Fleet Scores</h2>
+      {(['corporate', 'greatLakes', 'ohioValley', 'southeast'] as const).map(
+        (region) => (
+          <div key={region} className="grid grid-cols-3 gap-2">
+            <span className="capitalize self-center">{region}</span>
+            <input
+              type="number"
+              className="border p-2"
+              value={inputData.fleetScores[region].score}
+              onChange={(e) =>
+                handleFleetScoreChange(
+                  region,
+                  'score',
+                  Number(e.target.value)
+                )
+              }
+            />
+            <input
+              type="number"
+              className="border p-2"
+              value={inputData.fleetScores[region].change}
+              onChange={(e) =>
+                handleFleetScoreChange(
+                  region,
+                  'change',
+                  Number(e.target.value)
+                )
+              }
+            />
+          </div>
+        )
+      )}
+
+      {(
+        [
+          'hosViolations',
+          'safetyEvents',
+          'unassignedDriving',
+          'speedingEvents',
+          'personalConveyance',
+          'missedDVIR',
+        ] as const
+      ).map((field) => (
+        <div key={field} className="flex flex-col">
+          <label className="font-medium capitalize" htmlFor={field}>
+            {field}
+          </label>
+          <input
+            id={field}
+            type="number"
+            className="border p-2"
+            value={(inputData as any)[field].total}
+            onChange={(e) =>
+              handleSimpleFieldChange(field, Number(e.target.value))
+            }
+          />
+        </div>
+      ))}
+
+      <h2 className="text-xl font-bold">Contacts</h2>
+      {inputData.contacts.map((contact, idx) => (
+        <input
+          key={idx}
+          type="email"
+          className="border p-2 mb-2 w-full"
+          value={contact}
+          onChange={(e) => handleContactChange(idx, e.target.value)}
+        />
+      ))}
+      <button
+        type="button"
+        className="bg-blue-500 text-white px-3 py-1"
+        onClick={addContact}
+      >
+        Add Contact
+      </button>
+
+      <button
+        type="submit"
+        className="block bg-green-600 text-white px-4 py-2 mt-4"
+      >
+        Submit
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
+
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/react-app-env.d.ts
+++ b/frontend/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  content: ["./src/**/*.{js,jsx,ts,tsx}"],
+  theme: { extend: {} },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- scaffold basic React frontend with TypeScript
- configure TailwindCSS
- implement `DataInputForm` to capture CompanyInfo and InputData
- render the form in `App`

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851bc9ecfb8832c9c51f45655e10b87