### PR TITLE
Hardcode backend URL for front-end tests

### DIFF
--- a/frontend/src/components/DataInputForm.tsx
+++ b/frontend/src/components/DataInputForm.tsx
@@ -105,7 +105,7 @@ export default function DataInputForm() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    fetch('https://<YOUR_BACKEND>/generate', {
+    fetch('https://e95c0299-36c1-478e-ae78-e8d54752607f-00-2hnwn7mdyqnxz.worf.replit.dev/generate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ companyInfo, inputData }),


### PR DESCRIPTION
## Summary
- hardcode test backend URL in `DataInputForm`

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c0774b44832c88f8c77ed2efc5fe