### PR TITLE
Add dashboard view and PDF export features

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,10 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "recharts": "^2.8.0",
+    "react-markdown": "^9.0.0",
+    "html2pdf.js": "^0.10.1"
   },
   "devDependencies": {
     "tailwindcss": "^3.4.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,32 @@
-import React from 'react';
-import DataInputForm from './components/DataInputForm';
+import React, { useState } from 'react';
+import DataInputForm, { CompanyInfo, InputData } from './components/DataInputForm';
+import DashboardView from './components/DashboardView';
+import PDFExporter from './components/PDFExporter';
 
 export default function App() {
+  const [companyInfo, setCompanyInfo] = useState<CompanyInfo | null>(null);
+  const [inputData, setInputData] = useState<InputData | null>(null);
+  const [aiSections, setAiSections] = useState<{ title: string; markdown: string }[]>([]);
+
+  const handleGenerate = (
+    company: CompanyInfo,
+    input: InputData,
+    sections: { title: string; markdown: string }[]
+  ) => {
+    setCompanyInfo(company);
+    setInputData(input);
+    setAiSections(sections);
+  };
+
   return (
     <div className="container mx-auto p-4">
-      <DataInputForm />
+      <DataInputForm onGenerate={handleGenerate} />
+      {aiSections.length > 0 && companyInfo && inputData && (
+        <>
+          <DashboardView companyInfo={companyInfo} inputData={inputData} aiSections={aiSections} />
+          <PDFExporter />
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/DashboardView.tsx
+++ b/frontend/src/components/DashboardView.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  LineChart,
+  Line,
+} from 'recharts';
+import { CompanyInfo, InputData } from './DataInputForm';
+
+interface DashboardViewProps {
+  companyInfo: CompanyInfo;
+  inputData: InputData;
+  aiSections: { title: string; markdown: string }[];
+}
+
+const COLORS = ['#2563eb', '#dc2626', '#10b981', '#facc15'];
+
+export default function DashboardView({ companyInfo, inputData, aiSections }: DashboardViewProps) {
+  const scoreCards = Object.entries(inputData.fleetScores);
+  const violationData = Object.entries(inputData.hosViolations).map(([name, value]) => ({ name, value }));
+  const pieData = Object.entries(inputData.speedingEvents).map(([name, value]) => ({ name, value }));
+  const lineData = [
+    { week: 'Week 1', value: 0 },
+    { week: 'Week 2', value: 0 },
+    { week: 'Week 3', value: 0 },
+    { week: 'Week 4', value: 0 },
+  ];
+
+  return (
+    <div id="full-report" className="space-y-6">
+      <div className="grid grid-cols-4 gap-4">
+        {scoreCards.map(([region, { score, change }]) => (
+          <div key={region} className="border p-4 rounded shadow">
+            <h3 className="font-semibold capitalize">{region}</h3>
+            <p className="text-2xl font-bold">{score}</p>
+            <p className={change >= 0 ? 'text-green-600' : 'text-red-600'}>
+              {change >= 0 ? '+' : ''}
+              {change}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div className="h-64">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={violationData}>
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey="value" stackId="a" fill="#2563eb" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="h-64">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={lineData}>
+            <XAxis dataKey="week" />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="value" stroke="#dc2626" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="h-64">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie data={pieData} dataKey="value" nameKey="name" outerRadius={80}>
+              {pieData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="grid grid-cols-4 gap-4">
+        <div className="border p-4 rounded shadow">
+          <h4 className="font-semibold">Safety Events</h4>
+          <p className="text-xl">{inputData.safetyEvents.total}</p>
+        </div>
+        <div className="border p-4 rounded shadow">
+          <h4 className="font-semibold">Unassigned Driving</h4>
+          <p className="text-xl">{inputData.unassignedDriving.total}</p>
+        </div>
+        <div className="border p-4 rounded shadow">
+          <h4 className="font-semibold">Personal Conveyance</h4>
+          <p className="text-xl">{inputData.personalConveyance.totalHours ?? inputData.personalConveyance.total}</p>
+        </div>
+        <div className="border p-4 rounded shadow">
+          <h4 className="font-semibold">Missed DVIR</h4>
+          <p className="text-xl">{inputData.missedDVIR.total}</p>
+        </div>
+      </div>
+
+      {aiSections.map((sec) => (
+        <div key={sec.title} className="prose mt-6">
+          <h2>{sec.title}</h2>
+          <ReactMarkdown>{sec.markdown}</ReactMarkdown>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/DataInputForm.tsx
+++ b/frontend/src/components/DataInputForm.tsx
@@ -5,7 +5,7 @@ interface ScoreChange {
   change: number;
 }
 
-interface CompanyInfo {
+export interface CompanyInfo {
   name: string;
   industry: string;
   primaryColor: string;
@@ -14,7 +14,7 @@ interface CompanyInfo {
   reportPeriod: string;
 }
 
-interface InputData {
+export interface InputData {
   fleetScores: {
     corporate: ScoreChange;
     greatLakes: ScoreChange;
@@ -30,7 +30,15 @@ interface InputData {
   contacts: string[];
 }
 
-export default function DataInputForm() {
+interface DataInputFormProps {
+  onGenerate: (
+    company: CompanyInfo,
+    input: InputData,
+    sections: { title: string; markdown: string }[]
+  ) => void;
+}
+
+export default function DataInputForm({ onGenerate }: DataInputFormProps) {
   const [companyInfo, setCompanyInfo] = useState<CompanyInfo>({
     name: '',
     industry: '',
@@ -111,7 +119,11 @@ export default function DataInputForm() {
       body: JSON.stringify({ companyInfo, inputData }),
     })
       .then((res) => res.json())
-      .then(console.log)
+      .then((data) => {
+        if (data.sections) {
+          onGenerate(companyInfo, inputData, data.sections);
+        }
+      })
       .catch(console.error);
   };
 

--- a/frontend/src/components/PDFExporter.tsx
+++ b/frontend/src/components/PDFExporter.tsx
@@ -1,0 +1,18 @@
+import html2pdf from 'html2pdf.js';
+
+export default function PDFExporter() {
+  const handleExport = () => {
+    const el = document.getElementById('full-report');
+    if (!el) return;
+    html2pdf()
+      .set({ margin: 0.5, filename: 'DOT_Report.pdf', html2canvas: { scale: 2 } })
+      .from(el)
+      .save();
+  };
+
+  return (
+    <button onClick={handleExport} className="mt-4 bg-blue-600 text-white px-4 py-2 rounded">
+      Export PDF
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add `DashboardView` to visualize fleet data and render AI markdown
- export reports to PDF with `PDFExporter`
- wire dashboard and exporter in `App`
- extend `DataInputForm` to send results back to the app
- add required front-end deps in `package.json`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c64435cc832ca89fddb44d6fa5bb