### PR TITLE
Fix personal conveyance display in dashboard

### DIFF
--- a/frontend/src/components/DashboardView.tsx
+++ b/frontend/src/components/DashboardView.tsx
@@ -97,7 +97,10 @@ export default function DashboardView({ companyInfo, inputData, aiSections }: Da
         </div>
         <div className="border p-4 rounded shadow">
           <h4 className="font-semibold">Personal Conveyance</h4>
-          <p className="text-xl">{inputData.personalConveyance.totalHours ?? inputData.personalConveyance.total}</p>
+          <p className="text-xl">
+            { /* model only has a single numeric value */ }
+            {inputData.personalConveyance.total}
+          </p>
         </div>
         <div className="border p-4 rounded shadow">
           <h4 className="font-semibold">Missed DVIR</h4>


### PR DESCRIPTION
## Summary
- show Personal Conveyance total value without fallback to `totalHours`

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e094e0f4832c8cfff6e156d0f035