### PR TITLE
Fix html2pdf sourcemap warning

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "postinstall": "node ./scripts/remove-sourcemap.js"
   },
   "browserslist": {
     "production": [

--- a/frontend/scripts/remove-sourcemap.js
+++ b/frontend/scripts/remove-sourcemap.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+const distPath = path.join(__dirname, '..', 'node_modules', 'html2pdf.js', 'dist');
+const files = ['es6-promise.auto.js', 'es6-promise.auto.min.js', 'es6-promise.js', 'es6-promise.min.js'];
+
+files.forEach((file) => {
+  const fullPath = path.join(distPath, file);
+  if (fs.existsSync(fullPath)) {
+    let data = fs.readFileSync(fullPath, 'utf8');
+    const updated = data.replace(/\/\/# sourceMappingURL=.*\.map\n?/, '');
+    if (updated !== data) {
+      fs.writeFileSync(fullPath, updated, 'utf8');
+      console.log(`Removed sourceMappingURL from ${file}`);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add `remove-sourcemap.js` script to strip html2pdf source map directives
- run the script automatically via frontend `postinstall`

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e2174700832c88daef30829c629f