### PR TITLE
Add custom report text and sleek form styling

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 class ScoreChange(BaseModel):
     score: int
@@ -14,3 +14,4 @@ class InputData(BaseModel):
     personalConveyance: Dict[str, int]
     missedDVIR: Dict[str, int]
     contacts: List[str]
+    customText: Optional[str] = None

--- a/backend/openai_client.py
+++ b/backend/openai_client.py
@@ -9,6 +9,7 @@ def _build_prompt(req_json: dict) -> str:
     data = req_json["inputData"]
     template = """You are an expert fleet compliance analyst tasked with creating weekly DOT Fleet Compliance Snapshot reports.
 Generate a comprehensive report following this exact structure and format.
+[CUSTOM_TEXT]
 
 ---
 COMPANY INFORMATION REQUIRED
@@ -116,7 +117,9 @@ Colour palette & chart‑type guidance (see PDF for details)."""
                         "[LOGO_DETAILS]",
                         company["logoDesc"]).replace(
                             "[REPORT_PERIOD]",
-                            company["reportPeriod"]))
+                            company["reportPeriod"]).replace(
+                                "[CUSTOM_TEXT]",
+                                data.get("customText", "")))
 
     # Log the final prompt for debugging
     print(filled)

--- a/frontend/src/components/DataInputForm.tsx
+++ b/frontend/src/components/DataInputForm.tsx
@@ -28,6 +28,7 @@ export interface InputData {
   personalConveyance: { total: number };
   missedDVIR: { total: number };
   contacts: string[];
+  customText: string;
 }
 
 interface DataInputFormProps {
@@ -62,6 +63,7 @@ export default function DataInputForm({ onGenerate }: DataInputFormProps) {
     personalConveyance: { total: 0 },
     missedDVIR: { total: 0 },
     contacts: [''],
+    customText: '',
   });
 
   const handleCompanyChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -128,7 +130,7 @@ export default function DataInputForm({ onGenerate }: DataInputFormProps) {
   };
 
   return (
-    <form className="space-y-4" onSubmit={handleSubmit}>
+    <form className="space-y-4 bg-white p-6 rounded-lg shadow" onSubmit={handleSubmit}>
       <h2 className="text-xl font-bold">Company Info</h2>
       {(
         [
@@ -148,7 +150,7 @@ export default function DataInputForm({ onGenerate }: DataInputFormProps) {
             id={field}
             name={field}
             type="text"
-            className="border p-2"
+            className="border border-gray-300 rounded-md p-2 focus:ring-2 focus:ring-blue-500"
             value={companyInfo[field]}
             onChange={handleCompanyChange}
           />
@@ -162,7 +164,7 @@ export default function DataInputForm({ onGenerate }: DataInputFormProps) {
             <span className="capitalize self-center">{region}</span>
             <input
               type="number"
-              className="border p-2"
+              className="border border-gray-300 rounded-md p-2 focus:ring-2 focus:ring-blue-500"
               value={inputData.fleetScores[region].score}
               onChange={(e) =>
                 handleFleetScoreChange(
@@ -174,7 +176,7 @@ export default function DataInputForm({ onGenerate }: DataInputFormProps) {
             />
             <input
               type="number"
-              className="border p-2"
+              className="border border-gray-300 rounded-md p-2 focus:ring-2 focus:ring-blue-500"
               value={inputData.fleetScores[region].change}
               onChange={(e) =>
                 handleFleetScoreChange(
@@ -205,7 +207,7 @@ export default function DataInputForm({ onGenerate }: DataInputFormProps) {
           <input
             id={field}
             type="number"
-            className="border p-2"
+            className="border border-gray-300 rounded-md p-2 focus:ring-2 focus:ring-blue-500"
             value={(inputData as any)[field].total}
             onChange={(e) =>
               handleSimpleFieldChange(field, Number(e.target.value))
@@ -219,22 +221,32 @@ export default function DataInputForm({ onGenerate }: DataInputFormProps) {
         <input
           key={idx}
           type="email"
-          className="border p-2 mb-2 w-full"
+          className="border border-gray-300 rounded-md p-2 mb-2 w-full focus:ring-2 focus:ring-blue-500"
           value={contact}
           onChange={(e) => handleContactChange(idx, e.target.value)}
         />
       ))}
       <button
         type="button"
-        className="bg-blue-500 text-white px-3 py-1"
+        className="bg-blue-500 text-white px-3 py-1 rounded-md hover:bg-blue-600"
         onClick={addContact}
       >
         Add Contact
       </button>
 
+      <h2 className="text-xl font-bold">Custom Text</h2>
+      <textarea
+        className="border border-gray-300 rounded-md p-2 w-full focus:ring-2 focus:ring-blue-500"
+        rows={4}
+        value={inputData.customText}
+        onChange={(e) =>
+          setInputData((prev) => ({ ...prev, customText: e.target.value }))
+        }
+      />
+
       <button
         type="submit"
-        className="block bg-green-600 text-white px-4 py-2 mt-4"
+        className="block bg-green-600 text-white px-4 py-2 mt-4 rounded-md hover:bg-green-700"
       >
         Submit
       </button>


### PR DESCRIPTION
## Summary
- allow optional customText in input data models
- inject `[CUSTOM_TEXT]` placeholder in the OpenAI prompt
- update React form styling and add a Custom Text textarea

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e47cd70c832ca3ec384d2ef63a3f